### PR TITLE
Adding the template format version

### DIFF
--- a/test1-createstack.json
+++ b/test1-createstack.json
@@ -1,4 +1,6 @@
 {
+    "AWSTemplateFormatVersion" : "2010-09-09",
+
     "Description" : "Create a stack",
 
     "Resources": {


### PR DESCRIPTION
Okay, this is optional but a safe practice, in the event that AWS steps to a new version in the future